### PR TITLE
feat: Add Black, isort, and Pylint configuration with pre-commit hooks

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,0 +1,49 @@
+name: Code Quality
+
+on:
+  push:
+    branches: [ staging, main ]
+  pull_request:
+    branches: [ staging, main ]
+
+jobs:
+  code-quality:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.13'
+
+    - name: Cache pip packages
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Check code formatting with Black
+      run: |
+        black --check .
+
+    - name: Check import sorting with isort
+      run: |
+        isort --check-only .
+
+    - name: Lint with Pylint
+      run: |
+        pylint src/ overall_test.py
+
+    - name: Run pre-commit hooks
+      run: |
+        pip install pre-commit
+        pre-commit run --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,42 @@
+# Pre-commit hooks configuration
+# See https://pre-commit.com for more information
+repos:
+  # General file checks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+        args: ['--maxkb=1000']
+      - id: check-json
+        exclude: '^scripts/tpl_.*\.json$'
+      - id: check-toml
+      - id: check-merge-conflict
+      - id: debug-statements
+      - id: mixed-line-ending
+
+  # Black - Code formatter
+  - repo: https://github.com/psf/black
+    rev: 25.1.0
+    hooks:
+      - id: black
+        args: [--config=pyproject.toml]
+
+  # isort - Import sorter
+  - repo: https://github.com/PyCQA/isort
+    rev: 6.0.1
+    hooks:
+      - id: isort
+        args: [--settings-path=pyproject.toml]
+
+  # Pylint - Code linter
+  - repo: https://github.com/PyCQA/pylint
+    rev: v3.3.7
+    hooks:
+      - id: pylint
+        args: [--rcfile=.pylintrc]
+        additional_dependencies:
+          - pylint==3.3.7

--- a/.pylintrc
+++ b/.pylintrc
@@ -93,7 +93,7 @@ prefer-stubs=no
 
 # Minimum Python version to use for version dependent checks. Will default to
 # the version used to run pylint.
-py-version=3.10
+py-version=3.13
 
 # Discover python modules and packages in the file system subtree.
 recursive=no
@@ -345,7 +345,7 @@ indent-after-paren=4
 indent-string='    '
 
 # Maximum number of characters on a single line.
-max-line-length=100
+max-line-length=120
 
 # Maximum number of lines in a module.
 max-module-lines=1000
@@ -440,7 +440,13 @@ disable=raw-checker-failed,
         use-implicit-booleaness-not-comparison-to-zero,
         use-symbolic-message-instead,
         possibly-unused-variable,
-        too-many-locals
+        too-many-locals,
+        logging-fstring-interpolation,
+        missing-module-docstring,
+        missing-function-docstring,
+        missing-class-docstring,
+        fixme,
+        import-error
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,14 +23,79 @@ This repository contains a modular Python-based testing framework tailored for [
 
 1. Fork the repository.
 2. Create a new branch (`git checkout -b username/typeshort-description`).
-3. Commit your changes with a meaningful message.
-4. Push to your fork.
-5. Open a pull request against the `main` branch.
+3. Set up code quality tools (see below).
+4. Make your changes following our coding guidelines.
+5. Ensure all pre-commit checks pass.
+6. Commit your changes with a meaningful message.
+7. Push to your fork.
+8. Open a pull request against the `staging` branch.
 
 ## ✅ Coding Guidelines
 
+This project enforces strict code quality standards using automated tools. All contributions must adhere to these standards.
+
+### Code Style Standards
+
+We use three main tools to ensure consistent code quality:
+
+- **Black** (v25.1.0): Automatic code formatter with 100 character line limit
+- **isort** (v6.0.1): Import statement organizer (Black-compatible)
+- **Pylint** (v3.3.7): Static code analyzer and linter
+
+### Setting Up Code Quality Tools
+
+**First-time setup** (run once after cloning):
+
+```bash
+# Ensure you're in the virtual environment
+source .venv/bin/activate
+
+# Run the setup script
+./setup-pre-commit.sh
+```
+
+This installs pre-commit hooks that automatically check your code before each commit.
+
+### Before Committing
+
+Pre-commit hooks will automatically run on `git commit`. To manually check your code:
+
+```bash
+# Format all code
+make format
+
+# Run all checks
+make test
+
+# Or use pre-commit directly
+pre-commit run --all-files
+```
+
+### Manual Tool Usage
+
+```bash
+# Format code with Black
+black .
+
+# Sort imports
+isort .
+
+# Run Pylint
+pylint src/ overall_test.py
+```
+
+For detailed information about code style standards, see [CODE_STYLE.md](./CODE_STYLE.md).
+
+### General Guidelines
+
 - Keep your commits focused and clean.
-- Document your code appropriately.
+- Document your code appropriately (docstrings for public APIs).
+- Follow PEP 8 naming conventions (enforced by Pylint):
+  - Functions/variables: `snake_case`
+  - Classes: `PascalCase`
+  - Constants: `UPPER_CASE`
+- Maximum line length: 100 characters
+- All code must pass Black, isort, and Pylint checks before merging.
 
 ## 📄 License
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,58 @@
+.PHONY: help format lint check test clean install setup-hooks
+
+# Default target
+help:
+	@echo "Available targets:"
+	@echo "  make install       - Install all dependencies"
+	@echo "  make setup-hooks   - Set up pre-commit hooks"
+	@echo "  make format        - Format code with black and isort"
+	@echo "  make lint          - Run pylint on all Python files"
+	@echo "  make check         - Check code formatting without modifying files"
+	@echo "  make test          - Run all pre-commit checks"
+	@echo "  make clean         - Remove cache and temporary files"
+
+# Install dependencies
+install:
+	@echo "Installing dependencies..."
+	pip install -r requirements.txt
+
+# Set up pre-commit hooks
+setup-hooks:
+	@echo "Setting up pre-commit hooks..."
+	@chmod +x setup-pre-commit.sh
+	@./setup-pre-commit.sh
+
+# Format code with black and isort
+format:
+	@echo "Formatting code with black..."
+	black .
+	@echo "Sorting imports with isort..."
+	isort .
+
+# Run pylint
+lint:
+	@echo "Running pylint..."
+	pylint src/ overall_test.py
+
+# Check code formatting without modifying
+check:
+	@echo "Checking code formatting..."
+	black --check .
+	isort --check-only .
+	@echo "All formatting checks passed!"
+
+# Run all pre-commit checks
+test:
+	@echo "Running all pre-commit checks..."
+	pre-commit run --all-files
+
+# Clean up cache and temporary files
+clean:
+	@echo "Cleaning up cache and temporary files..."
+	find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
+	find . -type d -name "*.egg-info" -exec rm -rf {} + 2>/dev/null || true
+	find . -type d -name ".pytest_cache" -exec rm -rf {} + 2>/dev/null || true
+	find . -type d -name ".mypy_cache" -exec rm -rf {} + 2>/dev/null || true
+	find . -type f -name "*.pyc" -delete
+	find . -type f -name "*.pyo" -delete
+	@echo "Cleanup complete!"

--- a/README.md
+++ b/README.md
@@ -210,9 +210,18 @@ If you're interested in contributing to this testing framework, please read our 
 
 Whether it's reporting bugs, suggesting features, or submitting pull requests - your input is appreciated!
 
+### Code Quality Standards
+
+This project enforces code quality using:
+- **Black** for code formatting
+- **isort** for import sorting
+- **Pylint** for code analysis
+- **Pre-commit hooks** for automatic checks
+
+See [QUICK_START_CODE_QUALITY.md](./QUICK_START_CODE_QUALITY.md) for setup instructions.
+
 ## 📄 License
 
 This project is licensed under the [BSD 3-Clause License](./COPYING.md).
 
 By contributing to this repository, you agree that your contributions will be licensed under the same terms.
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,59 @@
 [tool.black]
 line-length = 100
+target-version = ['py310', 'py311', 'py312', 'py313']
+include = '\.pyi?$'
+extend-exclude = '''
+/(
+  # directories
+  \.eggs
+  | \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | _build
+  | buck-out
+  | build
+  | dist
+)/
+'''
 
 [tool.isort]
 profile = "black"
 line_length = 100
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+use_parentheses = true
+ensure_newline_before_comments = true
+skip_gitignore = true
+
+[tool.pylint.main]
+py-version = "3.13"
+ignore = ["CVS"]
+jobs = 0
+
+[tool.pylint.format]
+max-line-length = 120
+
+[tool.pylint.messages_control]
+disable = [
+    "raw-checker-failed",
+    "bad-inline-option",
+    "locally-disabled",
+    "file-ignored",
+    "suppressed-message",
+    "useless-suppression",
+    "deprecated-pragma",
+    "use-implicit-booleaness-not-comparison-to-string",
+    "use-implicit-booleaness-not-comparison-to-zero",
+    "use-symbolic-message-instead",
+    "possibly-unused-variable",
+    "too-many-locals",
+    "logging-fstring-interpolation",
+    "missing-module-docstring",
+    "missing-function-docstring",
+    "missing-class-docstring",
+    "fixme",
+    "import-error"
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,7 @@ orjson==3.10.18
 packaging==24.2
 pathspec==0.12.1
 platformdirs==4.3.8
+pre-commit==4.0.1
 pydantic==2.11.7
 pydantic_core==2.33.2
 pylint==3.3.7

--- a/setup-pre-commit.sh
+++ b/setup-pre-commit.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# Setup script for installing and configuring pre-commit hooks
+# This script automates the installation of code quality tools
+#
+
+set -e
+
+echo "================================================"
+echo "Setting up code quality tools for autokraft"
+echo "================================================"
+echo ""
+
+# Check if we're in a virtual environment
+if [ -z "$VIRTUAL_ENV" ]; then
+    echo "⚠️  Warning: No virtual environment detected!"
+    echo "   It's recommended to run this in a virtual environment."
+    echo ""
+    echo "   To create and activate one:"
+    echo "   $ python -m venv .venv"
+    echo "   $ source .venv/bin/activate"
+    echo ""
+    read -p "Continue anyway? (y/N) " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        exit 1
+    fi
+fi
+
+# Install pre-commit if not already installed
+echo "📦 Installing pre-commit..."
+pip install pre-commit==4.0.1
+
+# Install pre-commit hooks
+echo ""
+echo "🔧 Installing pre-commit git hooks..."
+pre-commit install
+
+# Run pre-commit on all files to verify setup
+echo ""
+echo "✅ Running pre-commit checks on all files..."
+echo "   (This may take a moment on first run)"
+pre-commit run --all-files || true
+
+echo ""
+echo "================================================"
+echo "✅ Setup complete!"
+echo "================================================"
+echo ""
+echo "Pre-commit hooks are now installed and will run automatically"
+echo "on every commit to ensure code quality."
+echo ""
+echo "Available commands:"
+echo "  - Run checks manually: pre-commit run --all-files"
+echo "  - Update hooks: pre-commit autoupdate"
+echo "  - Run specific hook: pre-commit run <hook-id>"
+echo ""
+echo "Code formatting tools:"
+echo "  - black: Code formatter (line length: 100)"
+echo "  - isort: Import sorter (compatible with black)"
+echo "  - pylint: Code linter and analyzer"
+echo ""


### PR DESCRIPTION
## Enforce code quality with isort, Black, and Pylint

This PR standardizes code style and quality checks across the project by enforcing **isort**, **Black**, and **Pylint** via pre-commit.

### What changed

After addressing issues surfaced during the initial `pre-commit` run, the following improvements were made:

1. **JSON check fix**

   * Excluded template JSON files (`scripts/tpl_*.json`) from validation since they intentionally contain placeholders.

2. **Pragmatic Pylint configuration**

   * Disabled overly noisy checks for initial adoption:

     * Missing docstrings
     * f-string logging warnings
     * TODO comments
     * Import-error warnings
   * Increased max line length to **120 chars** (Black remains at 100) to reduce false positives.

### How to verify

Run:

```bash
pre-commit run --all-files
```