### PR TITLE
fix: Resolve example applications failing to generate targets on new …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -240,3 +240,4 @@ initrd.cpio
 .sessions/
 logs
 
+Makefile.uk

--- a/scripts/tpl_app_fs_init.sh
+++ b/scripts/tpl_app_fs_init.sh
@@ -2,6 +2,7 @@
 
 init_rootfs="{rootfs}"
 testing_rootfs="{init_dir}/.rootfs-for-testing"
+app_dir="{app_dir}"
 
 # If no root filesystem, exit.
 if test -z "$init_rootfs"; then
@@ -23,5 +24,11 @@ else
     cp -r "$init_rootfs"/* "$testing_rootfs"
 fi
 
+# Create target directory if it doesn't exist
+if test ! -d "$app_dir"; then
+    echo "Creating target directory: $app_dir"
+    mkdir -p "$app_dir"
+fi
+
 # Create CPIO archive to be used as the embedded initrd.
-{base}/unikraft/support/scripts/mkcpio {app_dir}/initrd.cpio "$testing_rootfs"
+{base}/unikraft/support/scripts/mkcpio "$app_dir/initrd.cpio" "$testing_rootfs"

--- a/scripts/utils/new_session.sh
+++ b/scripts/utils/new_session.sh
@@ -1,7 +1,21 @@
 #!/bin/bash
 
-source testing-fw-venv/bin/activate
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Get the autokraft root directory (two levels up from scripts/utils)
+AUTOKRAFT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Activate virtual environment if it exists
+if [ -f "$AUTOKRAFT_DIR/testing-fw-venv/bin/activate" ]; then
+    source "$AUTOKRAFT_DIR/testing-fw-venv/bin/activate"
+elif [ -f "$AUTOKRAFT_DIR/venv/bin/activate" ]; then
+    source "$AUTOKRAFT_DIR/venv/bin/activate"
+elif [ -f "$AUTOKRAFT_DIR/.venv/bin/activate" ]; then
+    source "$AUTOKRAFT_DIR/.venv/bin/activate"
+fi
+# If no venv found, continue with system Python (assuming dependencies are installed)
 
 CATALOG_PATH=${1:-"/home/machine02/catalog/library/base"}
 
+cd "$AUTOKRAFT_DIR"
 python src/main.py "$CATALOG_PATH" --tests-dir .runtime_tests --app-dir-name .runtime_app --generate-only

--- a/src/app_config.py
+++ b/src/app_config.py
@@ -109,6 +109,35 @@ class AppConfig(Loggable):
 
         return self.config["rootfs"]
 
+    def _get_targets_from_kraftfile(self, kraftfile_path):
+        """Get targets from a Kraftfile.
+
+        Parse the Kraftfile and extract targets from the 'targets' field.
+
+        Args:
+            kraftfile_path: Path to the Kraftfile to parse.
+
+        Returns:
+            List of (plat, arch) tuples, or empty list if no targets found.
+        """
+        try:
+            with open(kraftfile_path, "r", encoding="utf-8") as stream:
+                data = yaml.safe_load(stream)
+
+            if not data or "targets" not in data:
+                return []
+
+            targets = []
+            for t in data["targets"]:
+                if isinstance(t, str) and "/" in t:
+                    plat = t.split("/")[0]
+                    arch = t.split("/")[1]
+                    targets.append((plat, arch))
+            return targets
+        except Exception as e:
+            self.logger.debug(f"Failed to parse Kraftfile at {kraftfile_path}: {e}")
+            return []
+
     def _get_targets_from_runtime(self):
         """Get targets (as pair of plat and arch) from runtime package.
 
@@ -116,27 +145,66 @@ class AppConfig(Loggable):
         useful for examples, that don't specify targets in the `Kraftfile`.
         But they specify a runtime that specifies targets.
 
+        Falls back to reading the runtime's Kraftfile from the catalog if
+        kraft pkg info fails.
+
         Populate the self.config['targets'] array as array of (plat, arch)
         pairs.
         """
 
+        runtime_query = self.config["runtime"].split(":")[0].replace("/", ":")
+        self.logger.debug(f"Querying kraft pkg info for runtime: {runtime_query}")
+
         kraft_proc = subprocess.Popen(
-            ["kraft", "pkg", "info", "--log-level", "panic", self.config["runtime"].split(":")[0].replace("/", ":"), "-o", "json"],
+            ["kraft", "pkg", "info", "--log-level", "panic", runtime_query, "-o", "json"],
             stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
         )
-        jq_proc = subprocess.Popen(
-            ["jq", "-r", ".[] | .plat"], stdin=subprocess.PIPE, stdout=subprocess.PIPE
-        )
-        kraft_output, _ = kraft_proc.communicate()
-        jq_out, _ = jq_proc.communicate(kraft_output)
+        kraft_output, kraft_err = kraft_proc.communicate()
 
         targets = []
-        for full_plat in jq_out.decode().split("\n"):
-            if full_plat:
-                plat = full_plat.split("/")[0]
-                arch = full_plat.split("/")[1]
-                targets.append((plat, arch))
-            self.config["targets"] = targets
+
+        if kraft_proc.returncode != 0:
+            self.logger.debug(f"kraft pkg info failed for '{runtime_query}': {kraft_err.decode().strip()}")
+        elif not kraft_output.strip():
+            self.logger.debug(f"kraft pkg info returned empty output for '{runtime_query}'")
+        else:
+            self.logger.debug(f"kraft pkg info output: {kraft_output.decode()[:500]}")
+
+            jq_proc = subprocess.Popen(
+                ["jq", "-r", ".[] | .plat"], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            )
+            jq_out, jq_err = jq_proc.communicate(kraft_output)
+
+            if jq_proc.returncode == 0:
+                for full_plat in jq_out.decode().split("\n"):
+                    if full_plat and "/" in full_plat:
+                        plat = full_plat.split("/")[0]
+                        arch = full_plat.split("/")[1]
+                        targets.append((plat, arch))
+
+        # Fallback: Try to read targets from the runtime's Kraftfile in the catalog
+        if not targets:
+            self.logger.debug("kraft pkg info did not return targets, trying catalog fallback...")
+            runtime_name = self.config["runtime"].split(":")[0]  # e.g., "node/21"
+
+            # Try to construct the catalog runtime path from app_dir
+            if "catalog" in self.app_dir:
+                catalog_base = self.app_dir.split("catalog")[0] + "catalog/library"
+                runtime_kraftfile = os.path.join(catalog_base, runtime_name, "Kraftfile")
+
+                if os.path.exists(runtime_kraftfile):
+                    self.logger.info(f"Reading targets from catalog runtime Kraftfile: {runtime_kraftfile}")
+                    targets = self._get_targets_from_kraftfile(runtime_kraftfile)
+                else:
+                    self.logger.debug(f"Runtime Kraftfile not found at: {runtime_kraftfile}")
+
+        if not targets:
+            self.logger.warning(f"No targets found for runtime '{runtime_query}'.")
+            self.logger.warning("Ensure the runtime package exists or the catalog contains the runtime Kraftfile.")
+
+        self.config["targets"] = targets
+        self.logger.debug(f"Retrieved targets from runtime: {targets}")
 
     def _parse_user_config(self, run_config_file):
         """Parse config.yaml file.

--- a/src/config.yaml.template
+++ b/src/config.yaml.template
@@ -1,2 +1,15 @@
+# Unikraft workspace base directory
+# This should be the PARENT directory containing:
+#   - unikraft/     (Unikraft core source)
+#   - libs/         (Unikraft libraries)
+#   - apps/         (Unikraft applications like app-elfloader)
+#
+# Example structure:
+#   /home/user/unikraft-workspace/
+#   ├── unikraft/   <- Unikraft core
+#   ├── libs/       <- Libraries
+#   └── apps/       <- Applications
+#
+# In this case, set base to: /home/user/unikraft-workspace
 source:
-  base: /absolute/path/to/your/unikraft/root
+  base: /absolute/path/to/your/unikraft/workspace

--- a/src/main.py
+++ b/src/main.py
@@ -314,6 +314,16 @@ def main():
 
         logger.info(f"Generated {len(targets)} target configuration(s) successfully.")
 
+        if len(targets) == 0:
+            logger.warning("No target configurations were generated!")
+            logger.warning("Possible causes:")
+            logger.warning("  - Runtime package not found (run 'kraft pkg info <runtime>' to verify)")
+            logger.warning("  - No matching compilers/VMMs available on this system")
+            logger.warning("  - All variant combinations excluded by variants.yaml")
+            if a.is_example():
+                logger.warning(f"  - For examples: check that runtime '{a.config.get('runtime', 'unknown')}' exists")
+            logger.warning("Run with --verbose for more details.")
+
         # If example, then create the key target runtimes.
         if a.is_example():
             logger.info("Generating key target runtimes for example application.")

--- a/src/tester_config.py
+++ b/src/tester_config.py
@@ -3,11 +3,15 @@ This module provide the TesterConfig class to retrive and store tester configura
 """
 
 import itertools
+import os
 import sys
 
 import yaml
 
 from utils.base import Loggable
+
+# Get the directory where this script is located
+_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
 class TesterConfig(Loggable):
@@ -19,18 +23,34 @@ class TesterConfig(Loggable):
     Provide configurations for target definition: get_target_configs()
     """
 
-    def __init__(self, variants_file="src/variants.yaml", config_file="src/config.yaml"):
+    def __init__(self, variants_file=None, config_file=None):
         super().__init__()
+
+        # Use absolute paths based on script location if not provided
+        if variants_file is None:
+            variants_file = os.path.join(_SCRIPT_DIR, "variants.yaml")
+        if config_file is None:
+            config_file = os.path.join(_SCRIPT_DIR, "config.yaml")
+
         try:
             with open(variants_file, "r", encoding="utf8") as stream:
                 self.config = yaml.safe_load(stream)
-                with open(config_file, "r", encoding="utf8") as stream:
-                    self.config.update(yaml.safe_load(stream))
-                self.variants = self._generate_variants()
-                self.target_configs = []
-            
         except IOError:
-            self.logger.error(f"Error: Unable to open configuration file '{variants_file}'")
+            self.logger.error(f"Error: Unable to open variants file '{variants_file}'")
+            self.logger.error("Please ensure variants.yaml exists in the src directory.")
+            sys.exit(1)
+
+        try:
+            with open(config_file, "r", encoding="utf8") as stream:
+                config_data = yaml.safe_load(stream)
+                if config_data:
+                    self.config.update(config_data)
+        except IOError:
+            self.logger.warning(f"Warning: Unable to open config file '{config_file}'")
+            self.logger.warning("Using defaults. Copy config.yaml.template to config.yaml and configure it.")
+
+        self.variants = self._generate_variants()
+        self.target_configs = []
 
     def _generate_full_variants(self):
         """Generate all possible configuration variants.


### PR DESCRIPTION
…setups

  - Use absolute paths for config file resolution in TesterConfig
  - Add fallback to read targets from catalog Kraftfile when kraft pkg info fails
  - Fix venv activation path in new_session.sh
  - Auto-create target directory for initrd.cpio generation
  - Clarify workspace structure in config.yaml.template