### PR TITLE
feat: add comprehensive isort, black, and pylint configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+.PHONY: lint format check
+
+# Format code with black and isort
+format:
+	black src/ overall_test.py
+	isort src/ overall_test.py
+
+# Run all linters (non-destructive)
+lint:
+	black --check src/ overall_test.py
+	isort --check-only src/ overall_test.py
+	pylint src/
+
+# Alias for lint
+check: lint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,29 @@
 [tool.black]
 line-length = 100
+target-version = ["py310"]
 
 [tool.isort]
 profile = "black"
 line_length = 100
+known_first_party = ["src"]
+skip_gitignore = true
+
+[tool.pylint.main]
+source-roots = ["src"]
+ignore-paths = ["tests", "scripts"]
+
+[tool.pylint.format]
+max-line-length = 100
+
+[tool.pylint."messages control"]
+disable = [
+    "C0114",  # missing-module-docstring (allow for small utility files)
+    "C0115",  # missing-class-docstring
+    "R0903",  # too-few-public-methods
+    "R0913",  # too-many-arguments
+    "W1203",  # logging-fstring-interpolation (f-strings are fine)
+]
+
+[tool.pylint.design]
+max-args = 8
+max-locals = 20


### PR DESCRIPTION
## Summary

- Extends `pyproject.toml` with comprehensive configuration for **isort**, **black**, and **pylint**
- Adds a `Makefile` with `format`, `lint`, and `check` targets for easy developer usage

## Configuration details

### black
- `target-version = ["py310"]` — explicit Python version target
- `line-length = 100` — consistent with existing config

### isort
- `profile = "black"` — compatible with black formatting
- `known_first_party = ["src"]` — properly categorizes project imports
- `skip_gitignore = true` — respects .gitignore

### pylint
- `source-roots = ["src"]` — correct import resolution
- `max-line-length = 100` — consistent with black
- Sensible disabled checks (logging f-strings, too-few-public-methods, etc.)
- `max-args = 8`, `max-locals = 20` — practical limits for the codebase

### Makefile
- `make format` — auto-format with black + isort
- `make lint` — check formatting + run pylint (non-destructive)
- `make check` — alias for lint

Fixes #4

## Test plan

- [x] `make format` runs black and isort on src/ and overall_test.py
- [x] `make lint` checks formatting and runs pylint
- [x] Configuration values are consistent across all three tools