### PR TITLE
feat: add --build-only mode to skip run phase

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -194,6 +194,12 @@ def parse_arguments():
     parser.add_argument(
         "--verbose", "-v", action="store_true", help="Enable verbose output (debug level logs)"
     )
+    parser.add_argument(
+        "--build-only",
+        "-b",
+        action="store_true",
+        help="Only build without running tests",
+    )
 
     return parser.parse_args()
 
@@ -359,7 +365,7 @@ def main():
                 
             logger.info(f"Running target {test_no + 1} of {len(targets)}")
             runner = TestRunner(target_config, app_dir, session)
-            runner.run_test()
+            runner.run_test(build_only=args.build_only)
             tests_run += 1
             
         logger.info(f"Completed {tests_run} test(s) successfully.")

--- a/src/test_runner.py
+++ b/src/test_runner.py
@@ -461,7 +461,7 @@ class TestRunner(Loggable):
             self.logger.error(f"[✗] {error_message}")
             raise Exception(error_message)
 
-    def run_test(self) -> None:
+    def run_test(self, build_only: bool = False) -> None:
         """
         Run the test for the target setup.
 
@@ -480,6 +480,9 @@ class TestRunner(Loggable):
             build_success = self._test_target_build(self.target.build_config.kernel_path)
             # Update the build status in the test-app-config/build_report.csv
             self._update_build_report(self.target, build_return_code, build_success)
+        if build_only:
+           self.logger.info(f"[✓] Build-only mode: skipping run for target {self.target.id}")
+           return
         # WARNING: TODO: Update the condition after keeping runtime_kernel created by kraft fetched by oci registry 
         if build_return_code == 0 and build_success or (self.target.build_config.is_example and self.target.config['build']['build_tool'] == 'kraft'):
             self.logger.info(f"[✓] Build successful for target: {self.target.id}")


### PR DESCRIPTION
### Description
This PR introduces a new 'build-only' mode in the Autokraft testing framework.  
Previously, Autokraft always built and ran unikernels, which could be time-consuming when only the build validation was needed.  

With this update:
- A new CLI flag `--build-only` (`-b`) is added in `main.py`.
- The flag is passed to `run_test()` in `test_runner.py`.
- When `build-only` mode is enabled, the framework:
  - Skips the run phase.
  - Updates the build report only, without generating run reports.

This provides faster validation of builds while keeping the code changes minimal.

---

### Changes
- `main.py`:
  - Added `--build-only / -b` argument.
  - Passed the `build_only` flag to `run_test()`.
- `test_runner.py`:
  - Updated `run_test()` to skip running tests if `build_only=True`.
  - Adjusted reporting logic to only update the build report in build-only mode.

---

### Why this approach
Other approaches considered:
1. Separate `build_test()` function → introduces code duplication.
2. Separate `BuildOnlyRunner` class → overkill for a small feature.

Adding a simple `build_only` flag to `run_test()` is the cleanest solution with minimal changes.

---

### Issue
Closes #3